### PR TITLE
fix: correct budoux GitHub link from nicklockwood to google

### DIFF
--- a/src/content/blog/magurodev-tech-stack.mdx
+++ b/src/content/blog/magurodev-tech-stack.mdx
@@ -77,7 +77,7 @@ Deno Deployにアジアリージョン（特に日本）が追加されたら、
   <figcaption>[Rust のトレイトで、associated type (関連型) か generic type (ジェネリクス) のどちらを使うか迷ったときの指針](/blog/associated-type-vs-generic-type-in-trait/) のOG画像</figcaption>
 </figure>
 
-これを実現しているのが[satori](https://github.com/vercel/satori)と[budoux](https://github.com/nicklockwood/budoux)だ。
+これを実現しているのが[satori](https://github.com/vercel/satori)と[budoux](https://github.com/google/budoux)だ。
 
 satoriはJSXをSVGに変換するライブラリで、美しいOG画像のデザインを可能にしている。デザインに関しては、Claude Codeに最初作ってもらったものがあまり良くなかったので、"polish it!!"と3回くらいお願いしたらこのようにクールな感じになった。
 


### PR DESCRIPTION
The budoux library is maintained by Google, not nicklockwood.