### PR TITLE
Add "Share on X" button to blog post pages

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -51,7 +51,7 @@ const tocHeadings = headings.filter((h) => h.depth >= 1 && h.depth <= 3);
 
     <footer class="post-footer">
       <a
-        href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(`https://maguro.dev/blog/${slug}/`)}&text=${encodeURIComponent(title)}`}
+        href={`https://x.com/intent/tweet?url=${encodeURIComponent(`https://maguro.dev/blog/${slug}/`)}&text=${encodeURIComponent(title)}`}
         target="_blank"
         rel="noopener noreferrer"
         class="share-button icon-link"


### PR DESCRIPTION
Add a share button at the bottom of each article that opens Twitter's
share intent with the post title and URL pre-filled.