### PR TITLE
Improve inline code contrast in light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,7 +8,7 @@
   --color-accent: #c05b4d;
   --color-accent-hover: #a84d41;
   --color-border: #e0e0e0;
-  --color-code-bg: #f5f5f5;
+  --color-code-bg: #e8e8e8;
 
   /* Typography */
   --font-sans:


### PR DESCRIPTION
Change code background from #f5f5f5 to #e8e8e8 to provide
better visual distinction against the #fafafa page background.