### PR TITLE
Detect X in-app browser and add bottom padding for its navigation bar

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,14 +55,22 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="twitter:image" content={ogImageUrl} />
 
     <!-- Theme: Prevent flash by setting theme before render -->
+    <!-- Browser detection: Detect X (Twitter) in-app browser -->
     <script is:inline>
       (function () {
+        // Theme detection
         const stored = localStorage.getItem("theme");
         const prefersDark = window.matchMedia(
           "(prefers-color-scheme: dark)",
         ).matches;
         const theme = stored || (prefersDark ? "dark" : "light");
         document.documentElement.setAttribute("data-theme", theme);
+
+        // X (Twitter) in-app browser detection
+        const ua = navigator.userAgent;
+        if (/Twitter/i.test(ua)) {
+          document.documentElement.setAttribute("data-browser", "x");
+        }
       })();
     </script>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -350,3 +350,9 @@ hr {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='9 14 4 9 9 4'/%3E%3Cpath d='M20 20v-7a4 4 0 0 0-4-4H4'/%3E%3C/svg%3E");
   -webkit-mask-size: contain;
 }
+
+/* X (Twitter) in-app browser adjustments */
+[data-browser="x"] body {
+  /* Add padding at the bottom to account for X's bottom navigation bar */
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 60px);
+}


### PR DESCRIPTION
- Add user agent detection for X (Twitter) in-app browser in BaseLayout
- Set data-browser="x" attribute on html element when detected
- Add 60px bottom padding (plus safe-area-inset) to prevent content from
  being obscured by X's bottom navigation bar