### PR TITLE
Use shorter variable name 'resp' consistently in code blocks

### DIFF
--- a/src/content/blog/fetch-double-await-explained.mdx
+++ b/src/content/blog/fetch-double-await-explained.mdx
@@ -8,8 +8,8 @@ description: "fetchでawaitを2回する設計の背景と、他言語HTTPクラ
 JavaScriptの [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) を使ったことがある人なら、こんなコードを書いたことがあると思います。
 
 ```js
-const response = await fetch("https://api.example.com/data");
-const data = await response.json();
+const resp = await fetch("https://api.example.com/data");
+const data = await resp.json();
 ```
 
 `await` を2回書いているのが気になったことはありませんか？1回の `await` で一気にレスポンスボディまで取れたら楽なのに、と思ったことはないでしょうか。
@@ -26,14 +26,14 @@ const data = await response.json();
 
 ```js
 // 1回目の await: レスポンスヘッダが届くまで待つ
-const response = await fetch("https://api.example.com/users");
+const resp = await fetch("https://api.example.com/users");
 
 // この時点でヘッダにはアクセスできる
-console.log(response.status);
-console.log(response.headers.get("Content-Type"));
+console.log(resp.status);
+console.log(resp.headers.get("Content-Type"));
 
 // 2回目の await: レスポンスボディを読み取る
-const users = await response.json();
+const users = await resp.json();
 ```
 
 `fetch()` が返す Promise は、レスポンスヘッダが届いた時点で解決されます。この時点ではまだボディは読み取れていません。ボディを読むには [`.json()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/json) や [`.text()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/text), [`bytes()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/bytes) といったメソッドを呼ぶ必要があり、これらも Promise を返すので再度 `await` が必要になります。
@@ -58,14 +58,14 @@ const { headers, body } = await fetch("https://api.example.com/users");
 現在の設計なら、ヘッダを見てからボディをストリームとして少しずつ処理できます。
 
 ```js
-const response = await fetch("https://example.com/huge-file.zip");
+const resp = await fetch("https://example.com/huge-file.zip");
 
 // Content-Length を確認してから処理を決められる
-const size = response.headers.get("Content-Length");
+const size = resp.headers.get("Content-Length");
 console.log(`file size = ${size} bytes`);
 
 // ストリームとして少しずつ処理
-const reader = response.body.getReader();
+const reader = resp.body.getReader();
 while (true) {
   const { done, value } = await reader.read();
   if (done) break;
@@ -82,10 +82,10 @@ while (true) {
 
 ```javascript
 // SSE エンドポイントへのリクエスト
-const response = await fetch("https://api.example.com/events");
+const resp = await fetch("https://api.example.com/events");
 
 // ストリームとして読み取る
-const reader = response.body.getReader();
+const reader = resp.body.getReader();
 const decoder = new TextDecoder();
 
 while (true) {
@@ -115,9 +115,9 @@ SSE のレスポンスは、サーバーが接続を閉じるか、クライア�
 ```js
 import axios from "axios";
 
-const response = await axios.get("https://api.example.com/users");
-// response.data にはすでにパース済みの JSON オブジェクトが入っている
-console.log(response.data);
+const resp = await axios.get("https://api.example.com/users");
+// resp.data にはすでにパース済みの JSON オブジェクトが入っている
+console.log(resp.data);
 ```
 
 `fetch` と違う設計ですね。
@@ -128,10 +128,10 @@ console.log(response.data);
 import axios from "axios";
 import fs from "node:fs";
 
-const response = await axios.get("https://example.com/large-file.zip", {
+const resp = await axios.get("https://example.com/large-file.zip", {
   responseType: "stream",
 });
-response.data.pipe(fs.createWriteStream("large-file.zip"));
+resp.data.pipe(fs.createWriteStream("large-file.zip"));
 ```
 
 `fetch` が「2回 `await`」方式を採用したのに対して、`axios` は「基本は1回 `await` だけど、レスポンスボディをストリームとして扱いたい場合はオプションを指定する」という形になっていることが分かります。
@@ -161,8 +161,8 @@ console.log(data);
 ```js
 import ky from "ky";
 
-const response = await ky.get("https://example.com/large-file.zip");
-const reader = response.body.getReader();
+const resp = await ky.get("https://example.com/large-file.zip");
+const reader = resp.body.getReader();
 // 以降は fetch と同じ
 ```
 
@@ -178,8 +178,8 @@ ky と同じ作者による、これまた人気のあるHTTPクライアント�
 import got from "got";
 
 // Promise API: レスポンス全体をメモリに読み込む
-const response = await got("https://api.example.com/users");
-console.log(response.body); // レスポンスボディ文字列が出力される
+const resp = await got("https://api.example.com/users");
+console.log(resp.body); // レスポンスボディ文字列が出力される
 ```
 
 ```js
@@ -206,13 +206,13 @@ Rust の [reqwest](https://github.com/seanmonstar/reqwest) も `fetch` と同じ
 
 ```rust
 // 1回目の await: レスポンスヘッダを取得
-let response = reqwest::get("https://api.example.com/data").await?;
+let resp = reqwest::get("https://api.example.com/data").await?;
 
 // ヘッダにアクセス可能
-println!("Status: {}", response.status());
+println!("Status: {}", resp.status());
 
 // 2回目の await: ボディを取得
-let body = response.text().await?;
+let body = resp.text().await?;
 ```
 
 かなり `fetch` に似ていますね。
@@ -235,16 +235,16 @@ Python の [aiohttp](https://docs.aiohttp.org/en/stable/) はおもしろくて�
 ```python
 async with aiohttp.ClientSession() as session:
     # 1回目のawait
-    async with session.get('http://python.org') as response:
+    async with session.get('http://python.org') as resp:
         # 2回目のawait
-        print(await response.text())
+        print(await resp.text())
 ```
 
 一方で requests は次のようにシンプルです。
 
 ```python
-response = requests.get('http://python.org')
-print(response.text)
+resp = requests.get('http://python.org')
+print(resp.text)
 ```
 
 この記事をここまで読んできたみなさんなら分かる通り、aiohttp は `fetch` と同じ思想で設計されています。公式ドキュメントでは次のように説明されています。


### PR DESCRIPTION
Replace 'response' with 'resp' across all code examples for
consistency and better mobile readability.