### PR TITLE
Add talks to about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -86,7 +86,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <h2>Talks</h2>
       <ul>
         <li>
-          <span class="period">2026</span>
           <a
             href="https://2026.tskaigi.org/talks/2"
             target="_blank"
@@ -96,7 +95,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <span class="role">TSKaigi 2026</span>
         </li>
         <li>
-          <span class="period">2025</span>
           <a
             href="https://www.docswell.com/s/magurotuna/Z37Q9J-2025-10-18-hono-conf-2025"
             target="_blank"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -83,6 +83,32 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     </section>
 
     <section class="history">
+      <h2>Talks</h2>
+      <ul>
+        <li>
+          <span class="period">2026</span>
+          <a
+            href="https://2026.tskaigi.org/talks/2"
+            target="_blank"
+            rel="noopener"
+            >tscからtsgoへ ── DenoのTypeScript基盤はどう変わったか</a
+          >
+          <span class="role">TSKaigi 2026</span>
+        </li>
+        <li>
+          <span class="period">2025</span>
+          <a
+            href="https://www.docswell.com/s/magurotuna/Z37Q9J-2025-10-18-hono-conf-2025"
+            target="_blank"
+            rel="noopener"
+            >Deno Sandbox – instant, disposable, and isolated VM for the AI era</a
+          >
+          <span class="role">Hono Conf 2025</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="history">
       <h2>Media</h2>
       <ul>
         <li>


### PR DESCRIPTION
## Summary
- add a Talks section to the About page
- list TSKaigi 2026 and Hono Conf 2025 with talk links

## Verification
- `npm run format:check -- src/pages/about.astro`
- `npm run build`
- `git diff --check`
- verified generated `dist/about/index.html` contains the Talks entries
